### PR TITLE
Added the option to define AD domain manually

### DIFF
--- a/src/main/java/org/pfl/sonar/plugins/ad/Constants.java
+++ b/src/main/java/org/pfl/sonar/plugins/ad/Constants.java
@@ -38,4 +38,6 @@ public interface Constants {
     public String LDAP_CTX_FACTORY               = "com.sun.jndi.ldap.LdapCtxFactory";
     public String SECURITY_AUTHENTICATION_SIMPLE = "simple";
     public String REFERRAL_FOLLOW                = "follow";
+    
+    public String CONFIG_OVERRIDE_AD_DOMAIN = "sonar.ad.domain";
 }


### PR DESCRIPTION
Hi Jiji,

I've been trying to run Sonar with this plugin on a linux box, which name is different than the AD domain I want to integrate Sonar with. That means auto discovery does not work for me, so I've extended the plugin to allow manual override of the domain name in `sonar.properties` file using `sonar.ad.domain` setting.

Cheers,
Sergey
